### PR TITLE
KeepUI: occlusion assistance opacity threshold

### DIFF
--- a/Shaders/KeepUI.fx
+++ b/Shaders/KeepUI.fx
@@ -51,6 +51,14 @@ uniform bool bKeepUIOcclude <
     ui_bind = "KeepUIOccludeAssist";
 > = 0;
 
+uniform float fKeepUIOccludeMinAlpha <
+    ui_type = "slider";
+    ui_category = "Options";
+    ui_label = "Occlusion Assistance Alpha Threshold";
+    ui_tooltip = "Set a minimum opacity threshold for occlusion assistance. If UI opacity is below the threshold, occlusion assistance will not be applied. Helps with screenspace illumination and DoF shaders.";
+    ui_min = 0; ui_max = 1;
+> = 0;
+
 #ifndef KeepUIOccludeAssist
 	#define KeepUIOccludeAssist 0
 #endif
@@ -95,7 +103,8 @@ void PS_KeepUI(float4 pos : SV_Position, float2 texcoord : TEXCOORD, out float4 
 #if KeepUIOccludeAssist
 void PS_OccludeUI(float4 pos : SV_Position, float2 texcoord : TEXCOORD, out float4 color : SV_Target)
 {
-    const float4 keep = tex2D(KeepUI_Sampler, texcoord);
+    float4 keep = tex2D(KeepUI_Sampler, texcoord);
+    keep.a *= step(fKeepUIOccludeMinAlpha, keep.a);
     color = float4(lerp(tex2D(ReShade::BackBuffer, texcoord), float4(0, 0, 0, 0), keep.a).rgb, keep.a);
 }
 #endif


### PR DESCRIPTION
This pull request adds a slider that allows the user to configure a minimum UI opacity to apply occlusion assistance. A correctly set opacity threshold (0.91 seems good for FFXIV, but I kept the default at 0 to match previous behaviour) gives you the previous benefits of occlusion assistance (e.g. keeps cutscene dialogue boxes from acting as light sources for SSGI in FFXIV) while minimizing dark shadows under transparent UI elements and causing less trouble with DOF shaders.
![OA on, old behaviour](https://user-images.githubusercontent.com/1952758/141195869-e404b703-19b3-4eaf-b914-64080e6d5880.png)
Here's the threshold at 0, which causes OA to behave exactly as it used to. The background behind transparent UI elements is darkened further by OA.
![Threshold set to 0.91](https://user-images.githubusercontent.com/1952758/141195822-d09dd4ff-0dfb-41d5-bbf0-0d76c3e77bc7.png)
Here's how setting the threshold higher looks. Only opaque and near-opaque UI pixels get OA. The shadow behind the name on the dialogue box and the chat background are not noticeably darker, but Nashu's sleeve is not lit up by the bright UI element directly below it.
![OA off](https://user-images.githubusercontent.com/1952758/141195845-65e1a9cf-bc4d-465d-8715-5d7c5ea1578c.png)
Here's the same scene with OA off for good measure. DoF picks up and adds bokeh to bright spots in the chat, and Nashu's sleeve is lit up by the textbox.