### PR TITLE
Remove AspectX and AspectY when doing transforms

### DIFF
--- a/Shaders/Censor.fxh
+++ b/Shaders/Censor.fxh
@@ -134,12 +134,10 @@ void PS_Censor(in float4 position : SV_Position, in float2 texCoord : TEXCOORD, 
     { \
         const float3 backColor = tex2D(ReShade::BackBuffer, texCoord).rgb; \
         const float3 pivot = float3(0.5, 0.5, 0.0); \
-        const float AspectX = (1.0 - BUFFER_WIDTH * (1.0 / BUFFER_HEIGHT)); \
-        const float AspectY = (1.0 - BUFFER_HEIGHT * (1.0 / BUFFER_WIDTH)); \
         const float3 mulUV = float3(texCoord.x, texCoord.y, 1); \
-        const float2 ScaleSize = (float2(BUFFER_WIDTH, BUFFER_HEIGHT) * CENSOR_SCALE / BUFFER_SCREEN_SIZE); \
-        const float ScaleX =  ScaleSize.x * AspectX * Censor_ScaleX; \
-        const float ScaleY =  ScaleSize.y * AspectY * Censor_ScaleY; \
+		const float2 ScaleSize = (float2(BUFFER_WIDTH, BUFFER_HEIGHT) * CENSOR_SCALE); \
+		const float ScaleX =  ScaleSize.x * Censor_ScaleX; \
+		const float ScaleY =  ScaleSize.y * Censor_ScaleY; \
         float Rotate = Censor_Rotate * (3.1415926 / 180.0); \
 		const int2 pixcoord = floor((BUFFER_SCREEN_SIZE * texCoord) / Censor_Cell_Size) * Censor_Cell_Size; \
 \
@@ -189,12 +187,12 @@ void PS_Censor(in float4 position : SV_Position, in float2 texCoord : TEXCOORD, 
             0, 0, 1 \
         ); \
         const float3x3 rotateMatrix = float3x3 ( \
-            (cos (Rotate) * AspectX), (sin(Rotate) * AspectX), 0, \
-            (-sin(Rotate) * AspectY), (cos(Rotate) * AspectY), 0, \
+            cos (Rotate), sin(Rotate), 0, \
+            -sin(Rotate), cos(Rotate), 0, \
             0, 0, 1 \
         ); \
 \
-        const float3 SumUV = mul (mul (mul (mulUV, positionMatrix), rotateMatrix), scaleMatrix); \
+        const float3 SumUV = mul (mul (mul (mulUV, positionMatrix) * float3(BUFFER_SCREEN_SIZE, 1.0f), rotateMatrix), scaleMatrix); \
 \
 		passColor *= all(SumUV + pivot == saturate(SumUV + pivot)); \
 \

--- a/Shaders/DisplayMod.fx
+++ b/Shaders/DisplayMod.fx
@@ -82,12 +82,10 @@ uniform float Display_Rotate <
 void PS_DisplayMod(in float4 position : SV_Position, in float2 texCoord : TEXCOORD, out float4 passColor : SV_Target)
 {
 	const float3 pivot = float3(0.5, 0.5, 0.0);
-	const float AspectX = (1.0 - BUFFER_WIDTH * (1.0 / BUFFER_HEIGHT));
-	const float AspectY = (1.0 - BUFFER_HEIGHT * (1.0 / BUFFER_WIDTH));
 	const float3 mulUV = float3(texCoord.x, texCoord.y, 1);
-	const float2 ScaleSize = (float2(BUFFER_WIDTH, BUFFER_HEIGHT) * Display_Scale / BUFFER_SCREEN_SIZE);
-	const float ScaleX =  ScaleSize.x * AspectX * Display_ScaleX;
-	const float ScaleY =  ScaleSize.y * AspectY * Display_ScaleY;
+	const float2 ScaleSize = (float2(BUFFER_WIDTH, BUFFER_HEIGHT) * Display_Scale);
+	const float ScaleX =  ScaleSize.x * Display_ScaleX;
+	const float ScaleY =  ScaleSize.y * Display_ScaleY;
 	float Rotate = Display_Rotate * (3.1415926 / 180.0);
 
 	switch(Display_SnapRotate)
@@ -122,12 +120,12 @@ void PS_DisplayMod(in float4 position : SV_Position, in float2 texCoord : TEXCOO
 		0, 0, 1
 	);
 	const float3x3 rotateMatrix = float3x3 (
-		(cos (Rotate) * AspectX), (sin(Rotate) * AspectX), 0,
-		(-sin(Rotate) * AspectY), (cos(Rotate) * AspectY), 0,
+		cos (Rotate), sin(Rotate), 0,
+		-sin(Rotate), cos(Rotate), 0,
 		0, 0, 1
 	);
 
-	const float3 SumUV = mul (mul (mul (mulUV, positionMatrix), rotateMatrix), scaleMatrix);
+	const float3 SumUV = mul (mul (mul (mulUV, positionMatrix) * float3(BUFFER_SCREEN_SIZE, 1.0f), rotateMatrix), scaleMatrix);
 	passColor = tex2D(ReShade::BackBuffer, SumUV.rg + pivot.rg) * all(SumUV + pivot == saturate(SumUV + pivot));
 }
 

--- a/Shaders/DropShadow.fxh
+++ b/Shaders/DropShadow.fxh
@@ -168,12 +168,10 @@ void PS_DropShadow(in float4 pos : SV_Position, float2 texCoord : TEXCOORD, out 
 	texCoord.y >= fCutoffMinY) \
 	{ \
 		const float3 pivot = float3(0.5, 0.5, 0.0); \
-		const float AspectX = (1.0 - BUFFER_WIDTH * (1.0 / BUFFER_HEIGHT)); \
-		const float AspectY = (1.0 - BUFFER_HEIGHT * (1.0 / BUFFER_WIDTH)); \
 		const float3 mulUV = float3(texCoord.x, texCoord.y, 1); \
-		const float2 ScaleSize = (float2(BUFFER_WIDTH, BUFFER_HEIGHT) * DROPSHADOW_SCALE / BUFFER_SCREEN_SIZE); \
-		const float ScaleX =  ScaleSize.x * AspectX * fScaleX; \
-		const float ScaleY =  ScaleSize.y * AspectY * fScaleY; \
+		const float2 ScaleSize = (float2(BUFFER_WIDTH, BUFFER_HEIGHT) * DROPSHADOW_SCALE); \
+		const float ScaleX =  ScaleSize.x * fScaleX; \
+		const float ScaleY =  ScaleSize.y * fScaleY; \
 		float Rotate = iRotate * (3.1415926 / 180.0); \
 \
 		switch(iSnapRotate) \
@@ -205,12 +203,12 @@ void PS_DropShadow(in float4 pos : SV_Position, float2 texCoord : TEXCOORD, out 
 			0, 0, 1 \
 		); \
 		const float3x3 rotateMatrix = float3x3 ( \
-		   (cos (Rotate) * AspectX), (sin(Rotate) * AspectX), 0, \
-			(-sin(Rotate) * AspectY), (cos(Rotate) * AspectY), 0, \
+			cos (Rotate), sin(Rotate), 0, \
+			-sin(Rotate), cos(Rotate), 0, \
 			0, 0, 1 \
 		); \
 \
-		const float3 SumUV = mul (mul (mul (mulUV, positionMatrix), rotateMatrix), scaleMatrix); \
+		const float3 SumUV = mul (mul (mul (mulUV, positionMatrix) * float3(BUFFER_SCREEN_SIZE, 1.0f), rotateMatrix), scaleMatrix); \
 		const float4 backColor = tex2D(ReShade::BackBuffer, texCoord); \
 		passColor = tex2D(DropShadow_Sampler, SumUV.rg + pivot.rg) * all(SumUV + pivot == saturate(SumUV + pivot)); \
 		 \

--- a/Shaders/Layer.fxh
+++ b/Shaders/Layer.fxh
@@ -137,12 +137,10 @@ uniform float Layer_Rotate < \
 void PS_Layer(in float4 pos : SV_Position, float2 texCoord : TEXCOORD, out float4 passColor : SV_Target) { \
 	const float4 backColor = tex2D(ReShade::BackBuffer, texCoord); \
 	const float3 pivot = float3(0.5, 0.5, 0.0); \
-	const float AspectX = (1.0 - BUFFER_WIDTH * (1.0 / BUFFER_HEIGHT)); \
-	const float AspectY = (1.0 - BUFFER_HEIGHT * (1.0 / BUFFER_WIDTH)); \
 	const float3 mulUV = float3(texCoord.x, texCoord.y, 1); \
-	const float2 ScaleSize = (float2(Layer_Size_X, Layer_Size_Y) * LAYER_SCALE / BUFFER_SCREEN_SIZE); \
-	const float ScaleX =  ScaleSize.x * AspectX * Layer_ScaleX; \
-	const float ScaleY =  ScaleSize.y * AspectY * Layer_ScaleY; \
+	const float2 ScaleSize = (float2(Layer_Size_X, Layer_Size_Y) * LAYER_SCALE); \
+	const float ScaleX =  ScaleSize.x * Layer_ScaleX; \
+	const float ScaleY =  ScaleSize.y * Layer_ScaleY; \
 	float Rotate = Layer_Rotate * (3.1415926 / 180.0); \
 \
 	switch(Layer_SnapRotate) \
@@ -174,12 +172,11 @@ void PS_Layer(in float4 pos : SV_Position, float2 texCoord : TEXCOORD, out float
 		0, 0, 1 \
 	); \
 	const float3x3 rotateMatrix = float3x3 ( \
-	   (cos (Rotate) * AspectX), (sin(Rotate) * AspectX), 0, \
-		(-sin(Rotate) * AspectY), (cos(Rotate) * AspectY), 0, \
+		cos (Rotate), sin(Rotate), 0, \
+		-sin(Rotate), cos(Rotate), 0, \
 		0, 0, 1 \
 	); \
-\
-	const float3 SumUV = mul (mul (mul (mulUV, positionMatrix), rotateMatrix), scaleMatrix); \
+	const float3 SumUV = mul (mul (mul (mulUV, positionMatrix) * float3(BUFFER_SCREEN_SIZE, 1.0f), rotateMatrix), scaleMatrix); \
 	passColor = tex2D(Layer_Sampler, SumUV.rg + pivot.rg) * all(SumUV + pivot == saturate(SumUV + pivot)); \
 \
 	passColor.rgb = (passColor.rgb - dot(passColor.rgb, 0.333)) * Layer_Saturation + dot(passColor.rgb, 0.333); \

--- a/Shaders/MultiLayer.fx
+++ b/Shaders/MultiLayer.fx
@@ -196,12 +196,10 @@ sampler MultiLayer_Sampler {
 void PS_Layer(in float4 pos : SV_Position, float2 texCoord : TEXCOORD, out float4 passColor : SV_Target) {
     const float4 backColor = tex2D(ReShade::BackBuffer, texCoord);
     const float3 pivot = float3(0.5, 0.5, 0.0);
-    const float AspectX = (1.0 - BUFFER_WIDTH * (1.0 / BUFFER_HEIGHT));
-    const float AspectY = (1.0 - BUFFER_HEIGHT * (1.0 / BUFFER_WIDTH));
     const float3 mulUV = float3(texCoord.x, texCoord.y, 1);
-    const float2 ScaleSize = (float2(MULTILAYER_SIZE_X, MULTILAYER_SIZE_Y) * Layer_Scale / BUFFER_SCREEN_SIZE);
-    const float ScaleX =  ScaleSize.x * AspectX * Layer_ScaleX;
-    const float ScaleY =  ScaleSize.y * AspectY * Layer_ScaleY;
+	const float2 ScaleSize = (float2(MULTILAYER_SIZE_X, MULTILAYER_SIZE_Y) * Layer_Scale);
+	const float ScaleX =  ScaleSize.x * Layer_ScaleX;
+	const float ScaleY =  ScaleSize.y * Layer_ScaleY;
     float Rotate = Layer_Rotate * (3.1415926 / 180.0);
 
     switch(Layer_SnapRotate)
@@ -233,12 +231,12 @@ void PS_Layer(in float4 pos : SV_Position, float2 texCoord : TEXCOORD, out float
         0, 0, 1
     );
     const float3x3 rotateMatrix = float3x3 (
-       (cos (Rotate) * AspectX), (sin(Rotate) * AspectX), 0,
-        (-sin(Rotate) * AspectY), (cos(Rotate) * AspectY), 0,
+        cos (Rotate), sin(Rotate), 0,
+        -sin(Rotate), cos(Rotate), 0,
         0, 0, 1
     );
 
-    const float3 SumUV = mul (mul (mul (mulUV, positionMatrix), rotateMatrix), scaleMatrix);
+    const float3 SumUV = mul (mul (mul (mulUV, positionMatrix) * float3(MULTILAYER_SIZE_X, MULTILAYER_SIZE_Y, 1.0f), rotateMatrix), scaleMatrix);
     passColor = tex2D(MultiLayer_Sampler, SumUV.rg + pivot.rg) * all(SumUV + pivot == saturate(SumUV + pivot));
 
 	passColor.rgb = (passColor.rgb - dot(passColor.rgb, 0.333)) * Layer_Saturation + dot(passColor.rgb, 0.333);

--- a/Shaders/MultiStageDepth.fx
+++ b/Shaders/MultiStageDepth.fx
@@ -187,12 +187,10 @@ void PS_MultiStageDepth(in float4 position : SV_Position, in float2 texCoord : T
     {
         const float3 backColor = tex2D(ReShade::BackBuffer, texCoord).rgb;
         const float3 pivot = float3(0.5, 0.5, 0.0);
-        const float AspectX = (1.0 - BUFFER_WIDTH * (1.0 / BUFFER_HEIGHT));
-        const float AspectY = (1.0 - BUFFER_HEIGHT * (1.0 / BUFFER_WIDTH));
         const float3 mulUV = float3(texCoord.x, texCoord.y, 1);
-        const float2 ScaleSize = (float2(BUFFER_WIDTH, BUFFER_HEIGHT) * Stage_Scale / BUFFER_SCREEN_SIZE);
-        const float ScaleX =  ScaleSize.x * AspectX * Stage_ScaleX;
-        const float ScaleY =  ScaleSize.y * AspectY * Stage_ScaleY;
+		const float2 ScaleSize = (float2(BUFFER_WIDTH, BUFFER_HEIGHT) * Stage_Scale);
+		const float ScaleX =  ScaleSize.x * Stage_ScaleX;
+		const float ScaleY =  ScaleSize.y * Stage_ScaleY;
         float Rotate = Stage_Rotate * (3.1415926 / 180.0);
 
         switch(Stage_SnapRotate)
@@ -224,12 +222,11 @@ void PS_MultiStageDepth(in float4 position : SV_Position, in float2 texCoord : T
             0, 0, 1
         );
         const float3x3 rotateMatrix = float3x3 (
-            (cos (Rotate) * AspectX), (sin(Rotate) * AspectX), 0,
-            (-sin(Rotate) * AspectY), (cos(Rotate) * AspectY), 0,
+            cos (Rotate), sin(Rotate), 0,
+            -sin(Rotate), cos(Rotate), 0,
             0, 0, 1
         );
-
-        const float3 SumUV = mul (mul (mul (mulUV, positionMatrix), rotateMatrix), scaleMatrix);
+        const float3 SumUV = mul (mul (mul (mulUV, positionMatrix) * float3(BUFFER_SCREEN_SIZE, 1.0f), rotateMatrix), scaleMatrix);
         passColor = tex2D(MultiStage_sampler, SumUV.rg + pivot.rg) * all(SumUV + pivot == saturate(SumUV + pivot));
 
 		passColor.rgb = (passColor.rgb - dot(passColor.rgb, 0.333)) * StageDepth_Saturation + dot(passColor.rgb, 0.333);

--- a/Shaders/StageDepth.fxh
+++ b/Shaders/StageDepth.fxh
@@ -146,12 +146,10 @@ void PS_StageDepth(in float4 position : SV_Position, in float2 texCoord : TEXCOO
 	{ \
 		const float3 backColor = tex2D(ReShade::BackBuffer, texCoord).rgb; \
 		const float3 pivot = float3(0.5, 0.5, 0.0); \
-		const float AspectX = (1.0 - BUFFER_WIDTH * (1.0 / BUFFER_HEIGHT)); \
-		const float AspectY = (1.0 - BUFFER_HEIGHT * (1.0 / BUFFER_WIDTH)); \
 		const float3 mulUV = float3(texCoord.x, texCoord.y, 1); \
-		const float2 ScaleSize = (float2(StageDepth_Size_X, StageDepth_Size_Y) * STAGEDEPTH_SCALE / BUFFER_SCREEN_SIZE); \
-		const float ScaleX =  ScaleSize.x * AspectX * StageDepth_ScaleX; \
-		const float ScaleY =  ScaleSize.y * AspectY * StageDepth_ScaleY; \
+		const float2 ScaleSize = (float2(StageDepth_Size_X, StageDepth_Size_Y) * STAGEDEPTH_SCALE); \
+		const float ScaleX =  ScaleSize.x * StageDepth_ScaleX; \
+		const float ScaleY =  ScaleSize.y * StageDepth_ScaleY; \
 		float Rotate = StageDepth_Rotate * (3.1415926 / 180.0); \
 \
 		switch(StageDepth_SnapRotate) \
@@ -183,17 +181,12 @@ void PS_StageDepth(in float4 position : SV_Position, in float2 texCoord : TEXCOO
 			0, 0, 1 \
 		); \
 		const float3x3 rotateMatrix = float3x3 ( \
-			(cos (Rotate) * AspectX), (sin(Rotate) * AspectX), 0, \
-			(-sin(Rotate) * AspectY), (cos(Rotate) * AspectY), 0, \
+			cos (Rotate), sin(Rotate), 0, \
+			-sin(Rotate), cos(Rotate), 0, \
 			0, 0, 1 \
 		); \
-\
-		const float3 SumUV = mul (mul (mul (mulUV, positionMatrix), rotateMatrix), scaleMatrix); \
+		const float3 SumUV = mul (mul (mul (mulUV, positionMatrix) * float3(BUFFER_SCREEN_SIZE, 1.0f), rotateMatrix), scaleMatrix); \
 		passColor = tex2D(StageDepth_Sampler, SumUV.rg + pivot.rg) * all(SumUV + pivot == saturate(SumUV + pivot)); \
-\
-		passColor.rgb = (passColor.rgb - dot(passColor.rgb, 0.333)) * StageDepth_Saturation + dot(passColor.rgb, 0.333); \
-\
-		passColor.rgb = passColor.rgb + StageDepth_Brightness; \
 \
 		passColor.rgb = ComHeaders::Blending::Blend(StageDepth_BlendMode, backColor, passColor.rgb, passColor.a * StageDepth_Opacity); \
 	} \

--- a/Shaders/VerticalPreviewer.fx
+++ b/Shaders/VerticalPreviewer.fx
@@ -658,11 +658,9 @@ void PS_VPreOut(in float4 pos : SV_Position, float2 texCoord : TEXCOORD, out flo
     else {
     const float3 pivot = float3(0.5, 0.5, 0.0);
     const float3 mulUV = float3(texCoord.x, texCoord.y, 1);
-    const float2 ScaleSize = (float2(BUFFER_WIDTH, BUFFER_HEIGHT) * cLayerVPre_Scale / BUFFER_SCREEN_SIZE);
-    const float AspectX = 1.0 - BUFFER_WIDTH * (1.0 / BUFFER_HEIGHT);
-    const float AspectY = 1.0 - BUFFER_HEIGHT * (1.0 / BUFFER_WIDTH);
-    const float ScaleX =  ScaleSize.x * AspectX * cLayerVPre_Scale;
-    const float ScaleY =  ScaleSize.y * AspectY * cLayerVPre_Scale;
+    const float2 ScaleSize = (float2(BUFFER_WIDTH, BUFFER_HEIGHT) * cLayerVPre_Scale);
+    const float ScaleX =  ScaleSize.x * cLayerVPre_Scale;
+    const float ScaleY =  ScaleSize.y * cLayerVPre_Scale;
 
     float Rotate = 0;
         switch(cLayerVPre_Angle)
@@ -698,12 +696,12 @@ void PS_VPreOut(in float4 pos : SV_Position, float2 texCoord : TEXCOORD, out flo
     );
 
     const float3x3 rotateMatrix = float3x3 (
-       (cos (Rotate) * AspectX), (sin(Rotate) * AspectX), 0,
-       (-sin(Rotate) * AspectY), (cos(Rotate) * AspectY), 0,
+        cos (Rotate), sin(Rotate), 0,
+        -sin(Rotate), cos(Rotate), 0,
         0, 0, 1
     );
 
-    float3 SumUV = mul (mul (mul (mulUV, positionMatrix), rotateMatrix), scaleMatrix);
+    float3 SumUV = mul (mul (mul (mulUV, positionMatrix) * float3(BUFFER_SCREEN_SIZE, 1.0f), rotateMatrix), scaleMatrix);
     float4 backColor = tex2D(samplerDrawARatio, texCoord);
         switch (cLayerVPre_Angle) {
             default:


### PR DESCRIPTION
`const float AspectX = (1.0 - BUFFER_WIDTH * (1.0 / BUFFER_HEIGHT));`

`AspectX` and `AspectY` are weird. Especially when `BUFFER_WIDTH == BUFFER_HEIGHT`, the rotation is totally broken.

BTW please also apply these changes to [GShade-Shaders](https://github.com/Mortalitas/GShade-Shaders)
